### PR TITLE
add note to payables

### DIFF
--- a/dynamics-gp/financials/PayablesManagement.md
+++ b/dynamics-gp/financials/PayablesManagement.md
@@ -1137,6 +1137,15 @@ recurring batches for transactions you enter on a regular basis.
 
 12. To print a batch edit list, choose File \>\> Print. Choose Save.
 
+
+[!NOTE]
+You may receive an error message "The fiscal period that contains this posting date has not been set up" when you create a credit card payment in a computer check batch.
+What can cause this error is the following: 
+1. You have a computer check set to have posting date from the transaction or
+2. You do not have EFT for payables registered under Tools | Setup | System | Registration
+
+If you enable EFT for payables, then a new field will appear in the print payment window that allows you to set the value and you can post without issue.  The other workaround is to set the posting date from the batch so you can see the posting date in the batch window.
+
 #### Payables batch approval workflow
 
 If your company uses the Workflow feature among its business controls, batches might have to be approved before posting. The rules for approving batches can be defined to fit your organization’s needs. Multiple approvers might be required, or approval might not be required for batches with few transactions or small currency amounts. When a batch is ready to be approved, approvers can be notified and the batches can be approved, using Microsoft Outlook or Microsoft Dynamics GP. After a batch is approved, it can be posted.

--- a/dynamics-gp/payroll/US19JanTaxR1.md
+++ b/dynamics-gp/payroll/US19JanTaxR1.md
@@ -8,7 +8,7 @@ ms.prod: dynamics-gp
 ms.topic: article
 ms.reviewer: edupont
 ms.author: theley
-ms.date: 01/07/2018
+ms.date: 07/11/2019
 ---
 # U.S. 2019 Payroll Tax Update
 
@@ -18,7 +18,9 @@ This tax update applies to:
 - Microsoft Dynamics GP 2016 on Microsoft SQL Server
 - Microsoft Dynamics GP 2015 on Microsoft SQL Server
 
-**Summary:** This document contains instructions for installing the 2019 U.S. Payroll Tax Update for Microsoft Dynamics GP.
+## 
+
+This document contains instructions for installing the 2019 U.S. Payroll Tax Update for Microsoft Dynamics GP.
 
 This is the third tax update for 2019. It includes state tax table changes that take effect January 1, 2019. It is recommended you install this update before processing payrolls for the 2019 year.
 
@@ -40,7 +42,7 @@ The Personal Exemption is $4,250 for Filing Status of MAR and SINGLE
 
 ### Withholding changes for Mississippi
 
-*Withholding rates for taxpayers filing as HOH, MAR1, and MAR2*
+Withholding rates for taxpayers filing as *HOH*, *MAR1*, and *MAR2*.
 
 | If Over     | But Not Over     | Tax Amount     | Tax Rate     | On Excess Over     |
 |-------------|------------------|----------------|--------------|--------------------|
@@ -71,7 +73,7 @@ The following tax changes are included in this update:
 
 ### Withholding changes for Alabama
 
-*Personal Exemption for taxpayers filing HOF*
+Personal Exemption for taxpayers filing *HOF*.
 
 | If Over     | But Not Over     | Tax Amount     | Tax Rate     | On Excess Over     |
 |-------------|------------------|----------------|--------------|--------------------|

--- a/dynamics-gp/payroll/US19JanTaxR1.md
+++ b/dynamics-gp/payroll/US19JanTaxR1.md
@@ -20,9 +20,35 @@ This tax update applies to:
 
 **Summary:** This document contains instructions for installing the 2019 U.S. Payroll Tax Update for Microsoft Dynamics GP.
 
-This is the second tax update for 2019. It includes state tax table changes that take effect January 1, 2019. It is recommended you install this update before processing payrolls for the 2019 year.
+This is the third tax update for 2019. It includes state tax table changes that take effect January 1, 2019. It is recommended you install this update before processing payrolls for the 2019 year.
 
 This document assumes that you are familiar with the Microsoft Dynamics GP U.S. Payroll module.
+
+## Changes in January Round 3 update
+- Minnesota
+- Mississippi
+
+## 2019 Federal tax changes
+There are no federal changes in the Round 3 tax table update.
+
+## 2019 state or territorial tax changes
+
+The following tax changes are included in this update:
+
+### Withholding changes for Minnesota
+The Personal Exemption is $4,250 for Filing Status of MAR and SINGLE
+
+### Withholding changes for Mississippi
+
+*Withholding rates for taxpayers filing as HOH, MAR1, and MAR2*
+
+| If Over     | But Not Over     | Tax Amount     | Tax Rate     | On Excess Over     |
+|-------------|------------------|----------------|--------------|--------------------|
+| 0           | 2,000            | 0              | 0.00%        | 0                  |
+| 2,000       | 5,000            | 0              | 3.00%        | 2,000              |
+| 5,000       | 10,000           | 150            | 4.00%        | 5,000              |
+| 10,000      | And Over         | 350            | 5.00%        | 10,000             |
+
 
 ## Changes in January Round 2 update
 - Alabama
@@ -754,7 +780,7 @@ Tax updates are distributed in the form of .CAB files. Copy the .CAB file to a f
 
 ## Installing the tax update
 
-The Round 2 January 2019 tax update installation can be run from any workstation. The update installs payroll tax table data on the server computer where your existing Microsoft Dynamics GP application data is located. You need to install the tax table update only once.
+The Round 3 July 2019 tax update installation can be run from any workstation. The update installs payroll tax table data on the server computer where your existing Microsoft Dynamics GP application data is located. You need to install the tax table update only once.
 
 If you have issues installing the update, review the article on [Tips to install the U.S. Payroll Tax
 Update.](https://community.dynamics.com/gp/b/dynamicsgp/archive/2017/05/09/tips-to-install-the-u-s-payroll-tax-update)
@@ -777,7 +803,7 @@ Before you begin, ask all Microsoft Dynamics GP users to exit the application un
 
 4.  Choose Process to start the update.
 
-5.  Verify that the latest Payroll tax table update has been installed. Choose Microsoft Dynamics GP menu \>\> Tools \>\> Setup \>\> System \>\> Payroll Tax. The Last Tax Update value should be 1/25/2019.
+5.  Verify that the latest Payroll tax table update has been installed. Choose Microsoft Dynamics GP menu \>\> Tools \>\> Setup \>\> System \>\> Payroll Tax. The Last Tax Update value should be 7/12/2019.
 
 ## What’s next
 


### PR DESCRIPTION
[!NOTE]
You may receive an error message "The fiscal period that contains this posting date has not been set up" when you create a credit card payment in a computer check batch.
What can cause this error is the following: 
1. You have a computer check set to have posting date from the transaction or
2. You do not have EFT for payables registered under Tools | Setup | System | Registration

If you enable EFT for payables, then a new field will appear in the print payment window that allows you to set the value and you can post without issue.  The other workaround is to set the posting date from the batch so you can see the posting date in the batch window.