### PR TITLE
Validation: Duplicate alt text and duplicate description error fixes.

### DIFF
--- a/dynamics-gp/distribution/Invoicing.md
+++ b/dynamics-gp/distribution/Invoicing.md
@@ -1,6 +1,6 @@
 ---
 title: "Invoicing in Dynamics GP"
-description: "Examine how the Invoicing module works in Microsoft Dynamics GP."
+description: "Learn how the Invoicing module works in Microsoft Dynamics GP with part one of this walkthrough, which covers setup."
 keywords: "invoicing"
 author: theley502
 manager: edupont

--- a/dynamics-gp/distribution/ProjAcctAdministration.md
+++ b/dynamics-gp/distribution/ProjAcctAdministration.md
@@ -136,7 +136,7 @@ The reconcile utility compares and recalculates data between tables to be sure t
 1. Open the **Reconcile Utility** or the **Reconcile Utility Periodic** window.  
 
     Tools \> Utilities \> Project \> PA Reconcile
-    ![A screenshot ](media/a42ce4bed0f79cb0fa2d01fbdc778c98.jpg)
+    ![Screenshot of the Reconcile Utility window, which shows the Budgets and fees and the Print Report option is selected.](media/a42ce4bed0f79cb0fa2d01fbdc778c98.jpg)
 
     Tools \> Utilities \> Project \> PA Reconcile Periodic
     ![A screenshot](media/14bb78293f2853e4d72ae9e1898d9304.jpg)
@@ -176,7 +176,7 @@ Before reconciling quantities, back up all accounting data for your company. You
 
     Tools \> Utilities \> Project \> PA Reconcile IV
 
-    ![A screenshot ](media/fffbd0e1136b85c71b7c4f982bc6d3ce.jpg)
+    ![Screenshot of the PA Reconcile Inventory Quantities window, which shows the item number range.](media/fffbd0e1136b85c71b7c4f982bc6d3ce.jpg)
 
 2. Enter or select the range of item numbers to reconcile.
 
@@ -192,7 +192,7 @@ You can re-create missing information in a database table. Some of the informati
 
     File \> Maintenance \> PA Check Links
 
-    ![A screenshot ](media/aaf798351a7478cfd2cc97a6aa3faed9.jpg)
+    ![Screenshot of the PA Check Links Window, which shows the Logical Tables and Selected Tables lists.](media/aaf798351a7478cfd2cc97a6aa3faed9.jpg)
 
 2. Specify the database table groups to include in check links by choosing **All** or selecting each table group and choosing **Insert**. This displays the table in the **Selected Tables** list. To delete a table from the list, select it and click **Remove**. The total number of records that exist in the selected tables will be displayed at the bottom of the window. The number is updated as items are selected and deleted from the **Selected Tables** list.
 

--- a/dynamics-gp/distribution/ProjAcctCostManagement.md
+++ b/dynamics-gp/distribution/ProjAcctCostManagement.md
@@ -712,7 +712,7 @@ in it.
 
 PACM 14.JPEG
 
-![Screenshot of the Contract Template Maintenance window.](media/PACM%2014.jpg)
+![Screenshot of the Contract Template Maintenance window, which is similar to the Contract Maintenance window.](media/PACM%2014.jpg)
 
 A screenshot of a cell phone Description automatically generated
 

--- a/dynamics-gp/distribution/invoicing-part-2.md
+++ b/dynamics-gp/distribution/invoicing-part-2.md
@@ -1,6 +1,6 @@
 ---
 title: "Invoicing in Dynamics GP - Part 2"
-description: "Examine how the Invoicing module works in Microsoft Dynamics GP."
+description: "Learn how the Invoicing module works in Microsoft Dynamics GP with part two of this walkthrough, which covers transaction entries."
 keywords: "invoicing"
 author: theley502
 manager: edupont

--- a/dynamics-gp/distribution/invoicing-part-3.md
+++ b/dynamics-gp/distribution/invoicing-part-3.md
@@ -1,6 +1,6 @@
 ---
 title: "Invoicing in Dynamics GP - Part 3"
-description: "Examine how the Invoicing module works in Microsoft Dynamics GP."
+description: "Learn how the Invoicing module works in Microsoft Dynamics GP with part three of this walkthrough, which covers transaction activity."
 keywords: "invoicing"
 author: theley502
 manager: edupont

--- a/dynamics-gp/distribution/invoicing-part-4.md
+++ b/dynamics-gp/distribution/invoicing-part-4.md
@@ -1,6 +1,6 @@
 ---
 title: "Invoicing in Dynamics GP - Part 4"
-description: "Examine how the Invoicing module works in Microsoft Dynamics GP."
+description: "Learn how the Invoicing module works in Microsoft Dynamics GP with part four of this walkthrough, which covers inquiries, reports, and utilities."
 keywords: "invoicing"
 author: theley502
 manager: edupont

--- a/dynamics-gp/distribution/purchase-order-processing-part3-receipts.md
+++ b/dynamics-gp/distribution/purchase-order-processing-part3-receipts.md
@@ -158,7 +158,7 @@ You can use the View \>\> Currency menu option or the currency list button to vi
 
 2. In the New group or its overflow menu, choose Shipment and Invoice Receipt to open the Receivings Transaction Entry window.
 
-    ![Screenshot of the Receivings Transaction Entry window.](media/POage102.jpg)
+    ![Screenshot of the Receivings Transaction Entry window as it appears by default.](media/POage102.jpg)
 
 3. Enter a vendor document number.
 
@@ -523,7 +523,7 @@ If you are using Project Accounting, the Project Number field and the Cost Categ
 
 2. In the New group or its overflow menu, choose In-Transit Inventory to open the Receivings Transaction Entry window.
 
-    ![Screenshot of the Receivings Transaction Entry window.](media/POage118.jpg)
+    ![Screenshot of the Receivings Transaction Entry window, which shows the window's default appearance.](media/POage118.jpg)
 
 3. Enter the receipt date.
 
@@ -1184,7 +1184,7 @@ You also can enter a lot split quantity, which is the breakpoint for creating se
 
 3. Choose Lot Numbers from the Track drop-down list, then choose the Track expansion button to open the Item Serial/Lot Number Definition window.
 
-    ![Screenshot of the Receivings Line Item Tax Detail Entry window.](media/POage141.jpg)
+    ![Screenshot of the Item Serial slash Lot Number Definition window.](media/POage141.jpg)
 
     Information for the item you selected, including the last lot number that was generated and any current mask information, will appear.
 
@@ -2201,7 +2201,7 @@ If you want match shipments for blanket purchase orders to an invoice receipt, s
 
 5. Choose Yes and the Match Shipments to Invoice window will open, where you can choose which line items can be matched. (If you choose No, the line items will be matched in shipment receipt number order.)
 
-    ![Screenshot of the Match Shipments to Invoice window.](media/POage174.jpg)
+    ![Screenshot of the Match Shipments to Invoice window, where you can choose which line items can be matched.](media/POage174.jpg)
 
     Currency amounts in this window may be displayed in functional or originating currency, depending on the view selected in the Purchasing Invoice Entry window.
 
@@ -3011,7 +3011,7 @@ If you are using landed costs, you can use the Match Shipments to Invoice window
 
 5. Choose the Match Shipments to Invoice expansion button to open the Match Shipments to Invoice window.
 
-    ![Screenshot of the Match Shipments to Invoice window.](media/POage186.jpg)
+    ![Screenshot of the Match Shipments to Invoice window, which shows the window's default appearance.](media/POage186.jpg)
 
     Currency amounts in this window may be displayed in functional or originating currency, depending on the view selected in the Purchasing Invoice Entry window.
 

--- a/dynamics-gp/distribution/purchase-order-processing-part3-receipts.md
+++ b/dynamics-gp/distribution/purchase-order-processing-part3-receipts.md
@@ -405,19 +405,19 @@ The sorting option you select determines the order in which objects appear in th
 
 - **PO/Items** Objects in the tree view and scrolling window are sorted first by purchase order number, then by the order items were entered on the purchase orders.
 
-    ![Screenshot of the PO slash Items object sorting window.](media/POage108.jpg)
+    ![Screenshot of the PO/Items object sorting window.](media/POage108.jpg)
 
 - **Item Number/PO** Objects in the tree view and scrolling window are sorted first by item number, then by purchase order number under each item.
 
-    ![Screenshot of the Item Number slash PO object sorting window.](media/POage110.jpg)
+    ![Screenshot of the Item Number/PO object sorting window.](media/POage110.jpg)
 
 - **Site/PO/Item Number** Objects in the tree view and scrolling window are sorted first by site, then by purchase order number under each site, then by item number under each purchase order.
 
-    ![screenshot of the Site slash PO slash Item Number object sorting window.](media/POage112.jpg)
+    ![screenshot of the Site/PO/Item Number object sorting window.](media/POage112.jpg)
 
 - **Site/Item Number/PO** Objects in the tree view and scrolling window are sorted first by site, then by item number under each site, then by purchase order number under each item.
 
-    ![Screenshot of the Site slash Item Number slash PO object sorting window.](media/POage114.jpg)
+    ![Screenshot of the Site/Item Number/PO object sorting window.](media/POage114.jpg)
 
 ### Receiving items from multiple purchase orders
 
@@ -1184,7 +1184,7 @@ You also can enter a lot split quantity, which is the breakpoint for creating se
 
 3. Choose Lot Numbers from the Track drop-down list, then choose the Track expansion button to open the Item Serial/Lot Number Definition window.
 
-    ![Screenshot of the Item Serial slash Lot Number Definition window, which shows 0 entered into the lot split quantity.](media/POage141.jpg)
+    ![Screenshot of the Item Serial/Lot Number Definition window, which shows 0 entered into the lot split quantity.](media/POage141.jpg)
 
     Information for the item you selected, including the last lot number that was generated and any current mask information, will appear.
 
@@ -1347,7 +1347,7 @@ Use the Item Serial/Lot Number Definition window to set up serial number masks f
 
 3. Choose Serial Numbers from the Track drop-down list, then choose the Track expansion button to open the Item Serial/Lot Number Definition window.
 
-    ![Screenshot of the Item Serial slash Lot Number Definition window.](media/POage147.jpg)
+    ![Screenshot of the Item Serial/Lot Number Definition window.](media/POage147.jpg)
 
     Information for the item you selected, including the last serial number that was generated and any current mask information, will appear.
 
@@ -1956,19 +1956,19 @@ The sorting option you select determines the order in which objects appear in th
 
 **PO/Items** Objects in the tree view and scrolling window are sorted first by purchase order number, then by the order items were entered on the purchase orders.
 
-![Screenshot of the PO slash Items sorting option window.](media/POage164.jpg)
+![Screenshot of the PO/Items sorting option window.](media/POage164.jpg)
 
 **Item Number/PO** Objects in the tree view and scrolling window are sorted first by item number, then by purchase order number under each item.
 
-![Screenshot of the Item Number slash PO sorting option window.](media/POage166.jpg)
+![Screenshot of the Item Number/PO sorting option window.](media/POage166.jpg)
 
 **Site/PO/Item Number** Objects in the tree view and scrolling window are sorted first by site, then by purchase order number under each site, then by item number under each purchase order.
 
-![Screenshot of the Site slash PO slash Item Number sorting option window.](media/POage168.jpg)
+![Screenshot of the Site/PO/Item Number sorting option window.](media/POage168.jpg)
 
 **Site/Item Number/PO** Objects in the tree view and scrolling window are sorted first by site, then by item number under each site, then by purchase order number under each item.
 
-![Screenshot of the Site slash Item Number slash PO sorting option window.](media/POage170.jpg)
+![Screenshot of the Site/Item Number/PO sorting option window.](media/POage170.jpg)
 
 ### Invoicing items from multiple purchase orders
 

--- a/dynamics-gp/distribution/purchase-order-processing-part3-receipts.md
+++ b/dynamics-gp/distribution/purchase-order-processing-part3-receipts.md
@@ -1184,7 +1184,7 @@ You also can enter a lot split quantity, which is the breakpoint for creating se
 
 3. Choose Lot Numbers from the Track drop-down list, then choose the Track expansion button to open the Item Serial/Lot Number Definition window.
 
-    ![Screenshot of the Item Serial slash Lot Number Definition window.](media/POage141.jpg)
+    ![Screenshot of the Item Serial slash Lot Number Definition window, which shows 0 entered into the lot split quantity.](media/POage141.jpg)
 
     Information for the item you selected, including the last lot number that was generated and any current mask information, will appear.
 

--- a/dynamics-gp/distribution/purchase-order-processing-part3-receipts.md
+++ b/dynamics-gp/distribution/purchase-order-processing-part3-receipts.md
@@ -158,7 +158,7 @@ You can use the View \>\> Currency menu option or the currency list button to vi
 
 2. In the New group or its overflow menu, choose Shipment and Invoice Receipt to open the Receivings Transaction Entry window.
 
-    ![screenshot Receivings Transaction Entry](media/POage102.jpg)
+    ![Screenshot of the Receivings Transaction Entry window.](media/POage102.jpg)
 
 3. Enter a vendor document number.
 
@@ -405,19 +405,19 @@ The sorting option you select determines the order in which objects appear in th
 
 - **PO/Items** Objects in the tree view and scrolling window are sorted first by purchase order number, then by the order items were entered on the purchase orders.
 
-    ![screenshot PO/Items](media/POage108.jpg)
+    ![Screenshot of the PO slash Items object sorting window.](media/POage108.jpg)
 
 - **Item Number/PO** Objects in the tree view and scrolling window are sorted first by item number, then by purchase order number under each item.
 
-    ![screenshot Item Number/PO](media/POage110.jpg)
+    ![Screenshot of the Item Number slash PO object sorting window.](media/POage110.jpg)
 
 - **Site/PO/Item Number** Objects in the tree view and scrolling window are sorted first by site, then by purchase order number under each site, then by item number under each purchase order.
 
-    ![screenshot Site/PO/Item Number](media/POage112.jpg)
+    ![screenshot of the Site slash PO slash Item Number object sorting window.](media/POage112.jpg)
 
 - **Site/Item Number/PO** Objects in the tree view and scrolling window are sorted first by site, then by item number under each site, then by purchase order number under each item.
 
-    ![screenshot Site/Item Number/PO](media/POage114.jpg)
+    ![Screenshot of the Site slash Item Number slash PO object sorting window.](media/POage114.jpg)
 
 ### Receiving items from multiple purchase orders
 
@@ -523,7 +523,7 @@ If you are using Project Accounting, the Project Number field and the Cost Categ
 
 2. In the New group or its overflow menu, choose In-Transit Inventory to open the Receivings Transaction Entry window.
 
-    ![screenshot Receivings Transaction Entry](media/POage118.jpg)
+    ![Screenshot of the Receivings Transaction Entry window.](media/POage118.jpg)
 
 3. Enter the receipt date.
 
@@ -657,7 +657,7 @@ You can use the View \>\> Currency menu option or the currency list button to vi
 1. Open the Receivings Transaction Entry window.
     (Purchasing \>\> Transactions \>\> Receivings Transaction Entry)
 
-    ![screenshot Receivings Transaction Entry](media/POage130.jpg)
+    ![Screenshot of the Receivings Transaction Entry window.](media/POage130.jpg)
 
 2. Select Shipment/Invoice as the document type for the transaction.
 
@@ -886,7 +886,7 @@ If you are using Workflow, the purchase order must be approved before you can re
     > [!NOTE]
     > If you entered a vendor ID, the Select Purchase Order Items window will open instead of the Select Purchase Order window.
 
-    ![screenshot Select Purchase Order](media/POage134.jpg)
+    ![Screenshot of the Select Purchase Order Items window.](media/POage134.jpg)
 
 5. Enter or select a purchase order for which you want to receive line items.
 
@@ -1041,7 +1041,7 @@ If you are using Project Accounting, the Project Number field and the Cost Categ
 
 2. Enter or select a receipt number and vendor and open the Receivings Item Detail Entry window by choosing the Vendor Item or Item expansion button.
 
-    ![screenshot Receivings Item Detail Entry](media/POage136.jpg)
+    ![Screenshot of the Receivings Line Item Tax Detail Entry window.](media/POage136.jpg)
 
     Currency amounts in this window may be displayed in the functional or originating currency, depending on the view selected in the Receivings Transaction Entry window.
 
@@ -1184,7 +1184,7 @@ You also can enter a lot split quantity, which is the breakpoint for creating se
 
 3. Choose Lot Numbers from the Track drop-down list, then choose the Track expansion button to open the Item Serial/Lot Number Definition window.
 
-    ![screenshot Item Serial/Lot Number Definition](media/POage141.jpg)
+    ![Screenshot of the Receivings Line Item Tax Detail Entry window.](media/POage141.jpg)
 
     Information for the item you selected, including the last lot number that was generated and any current mask information, will appear.
 
@@ -1347,7 +1347,7 @@ Use the Item Serial/Lot Number Definition window to set up serial number masks f
 
 3. Choose Serial Numbers from the Track drop-down list, then choose the Track expansion button to open the Item Serial/Lot Number Definition window.
 
-    ![screenshot Item Serial/Lot Number Definition](media/POage147.jpg)
+    ![Screenshot of the Item Serial slash Lot Number Definition window.](media/POage147.jpg)
 
     Information for the item you selected, including the last serial number that was generated and any current mask information, will appear.
 
@@ -1652,7 +1652,7 @@ If Intrastat information was entered for the vendor's ship from address ID, that
 
 3. Choose the EU button to open the Purchasing Intrastat Entry window. You can also open the Purchasing Intrastat Entry window by choosing the EU button in the Receivings Item Detail Entry window.
 
-    ![screenshot Receivings Item Detail Entry](media/POage155.jpg)
+    ![Screenshot of the Purchasing Intrastat Entry window.](media/POage155.jpg)
 
 4. Enter Intrastat information, or change the default entries, if necessary.
 
@@ -1819,7 +1819,7 @@ If you are using Project Accounting, the Project Number field and the Cost Categ
 
 5. Choose Yes and the Match Shipments to Invoice window will open, where you can choose which line items can be matched. (If you choose No, the line items will be matched in shipment receipt number order.)
 
-    ![screenshot Match Shipments to Invoice](media/POage160.jpg)
+    ![Screenshot of the Match Shipments to Invoice window.](media/POage160.jpg)
 
     Currency amounts in this window may be displayed in functional or originating currency, depending on the view selected in the Purchasing Invoice Entry window.
 
@@ -1898,7 +1898,7 @@ If you are using Project Accounting, the Project Number field and the Cost Categ
     > [!NOTE]
     > If you entered a vendor ID, the Select Purchase Order Items window will open instead of the Select Purchase Order window.
 
-    ![screenshot Select Purchase Order](media/POage162.jpg)
+    ![Screenshot of the Select Purchase Order window.](media/POage162.jpg)
 
 4. Enter or select the purchase order for which you want to invoice all line items.
 
@@ -1956,19 +1956,19 @@ The sorting option you select determines the order in which objects appear in th
 
 **PO/Items** Objects in the tree view and scrolling window are sorted first by purchase order number, then by the order items were entered on the purchase orders.
 
-![screenshot PO/Items](media/POage164.jpg)
+![Screenshot of the PO slash Items sorting option window.](media/POage164.jpg)
 
 **Item Number/PO** Objects in the tree view and scrolling window are sorted first by item number, then by purchase order number under each item.
 
-![screenshot Item Number/PO](media/POage166.jpg)
+![Screenshot of the Item Number slash PO sorting option window.](media/POage166.jpg)
 
 **Site/PO/Item Number** Objects in the tree view and scrolling window are sorted first by site, then by purchase order number under each site, then by item number under each purchase order.
 
-![screenshot Site/PO/Item Number](media/POage168.jpg)
+![Screenshot of the Site slash PO slash Item Number sorting option window.](media/POage168.jpg)
 
 **Site/Item Number/PO** Objects in the tree view and scrolling window are sorted first by site, then by item number under each site, then by purchase order number under each item.
 
-![screenshot Site/Item Number/PO](media/POage170.jpg)
+![Screenshot of the Site slash Item Number slash PO sorting option window.](media/POage170.jpg)
 
 ### Invoicing items from multiple purchase orders
 
@@ -2201,7 +2201,7 @@ If you want match shipments for blanket purchase orders to an invoice receipt, s
 
 5. Choose Yes and the Match Shipments to Invoice window will open, where you can choose which line items can be matched. (If you choose No, the line items will be matched in shipment receipt number order.)
 
-    ![screenshot Match Shipments to Invoice](media/POage174.jpg)
+    ![Screenshot of the Match Shipments to Invoice window.](media/POage174.jpg)
 
     Currency amounts in this window may be displayed in functional or originating currency, depending on the view selected in the Purchasing Invoice Entry window.
 
@@ -2278,7 +2278,7 @@ Use the Select Purchase Order window to select a purchase order to quickly enter
     > [!NOTE]
     > If you entered a vendor ID, the Select Purchase Order Items window will open instead of the Select Purchase Order window.
 
-    ![screenshot Select Purchase Order](media/POage162.jpg)
+    ![Screenshot of the Select Purchase Order window.](media/POage162.jpg)
 
 4. Enter or select the purchase order for which you want to invoice all line items.
 
@@ -3011,7 +3011,7 @@ If you are using landed costs, you can use the Match Shipments to Invoice window
 
 5. Choose the Match Shipments to Invoice expansion button to open the Match Shipments to Invoice window.
 
-    ![screenshot Match Shipments to Invoice](media/POage186.jpg)
+    ![Screenshot of the Match Shipments to Invoice window.](media/POage186.jpg)
 
     Currency amounts in this window may be displayed in functional or originating currency, depending on the view selected in the Purchasing Invoice Entry window.
 

--- a/dynamics-gp/distribution/purchase-order-processing.md
+++ b/dynamics-gp/distribution/purchase-order-processing.md
@@ -275,7 +275,7 @@ Changing the decimal place setting for a currency won't change the decimal place
 1.  Open the Purchasing Non-Inventoried Currency Decimals Setup window. 
     (Purchasing \>\> Setup \>\> Purchase Order Processing \>\> Currency expansion button)
 
-![screenshot](media/POage013.jpg)
+![Screenshot of the Purchasing Non-Inventoried Currency Decimals Setup window.](media/POage013.jpg)
 
 2.  In the Currency Decimals column, change the number of currency decimal places to use for non-inventoried items. Amounts will appear in the format defined in this window whenever a non-inventoried item is entered for a specific currency.
 
@@ -294,7 +294,7 @@ Use the Purchase Order Processing Setup Options window to set up the tax calcula
 1.  Open the Purchase Order Processing Setup Options window.
     (Purchasing \>\> Setup \>\> Purchase Order Processing \>\> Options button)
 
-![screenshot](media/POage015.jpg)
+![Screenshot of the Purchase Order Processing Setup Options window.](media/POage015.jpg)
 
 2.  Mark the type of tax calculation to use on documents.
 
@@ -330,7 +330,7 @@ Use the Receivings User-Defined Fields Setup window to enter labels for up to 35
 1.  Open the Receivings User-Defined Fields Setup window.
     (Purchasing \>\> Setup \>\> Purchase Order Processing \>\> Receivings UserDefined button)
 
-![screenshot](media/POage017.jpg)
+![Screenshot of the Receivings User Defined Fields Setup window.](media/POage017.jpg)
 
 2.  Enter as many as five list fields. Choose the expansion button next to each list name you've entered; the Receivings User-Defined List Setup window will appear. Use this window to enter values for each list.
 
@@ -353,7 +353,7 @@ Use the Comment Setup window to define comments for each company. You can use th
 1.  Open the Comment Setup window.
     (Administration \>\> Setup \>\> Company \>\> Comments)
 
-![screenshot](media/POage019.jpg)
+![Screenshot of the Comment Setup window as it appears by default.](media/POage019.jpg)
 
 2.  Enter a short identifier for the comment.
 
@@ -388,7 +388,7 @@ Use the Buyer Maintenance window to add new buyer IDs. For example, a buyer ID c
 1.  Open the Buyer Maintenance window. 
     (Purchasing \>\> Cards \>\> Buyers)
 
-![screenshot](media/POage022.jpg)
+![Screenshot of the Buyer Maintenance window.](media/POage022.jpg)
 
 2.  Enter a buyer ID in the Buyer ID field.
 
@@ -470,7 +470,7 @@ If you are using Project Accounting, you can't generate purchase orders for proj
 1.  Open the Purchase Order Processing Setup Options window.
     (Purchasing \>\> Setup \>\> Purchase Order Processing \>\> Options button)
 
-![screenshot](media/POage024.jpg)
+![Screenshot of the Purchase Order Processing Setup Options window.](media/POage024.jpg)
 
 2.  Select a default order method for automatically generated purchase orders.
 
@@ -537,7 +537,7 @@ If you are using Project Accounting, you can't generate purchase orders for proj
 1.  Open the Purchase Order Generator Map Sites window.
     (Purchasing \>\> Setup \>\> Purchase Order Generator Map Sites)
 
-![screenshot](media/POage026.jpg)
+![Screenshot of the Purchase Order Generator Map Sites window.](media/POage026.jpg)
 
 All inventory site IDs defined for the current company will be displayed.
 
@@ -609,7 +609,7 @@ Use the PA Purchase Order Processing Setup window to set up preferences and defa
 1.  Open the PA Purchase Order Processing Setup Options window.
     (Purchasing\>\> Setup \>\> Purchase Order Processing \>\> Project button)
 
-![screenshot](media/POage028.jpg)
+![Screenshot of the PA Purchase Order Processing Setup Options window.](media/POage028.jpg)
 
 2.  Enter purchase order label descriptions for three purchase order formats that are available when you are using Project Accounting. These labels will be displayed as options in the Purchase Order Format list in the Purchase Order Print Options window and the Print Purchasing Documents window.
 

--- a/dynamics-gp/distribution/purchase-order-processing.md
+++ b/dynamics-gp/distribution/purchase-order-processing.md
@@ -470,7 +470,7 @@ If you are using Project Accounting, you can't generate purchase orders for proj
 1.  Open the Purchase Order Processing Setup Options window.
     (Purchasing \>\> Setup \>\> Purchase Order Processing \>\> Options button)
 
-![Screenshot of the Purchase Order Processing Setup Options window.](media/POage024.jpg)
+![Screenshot of the Purchase Order Processing Setup Options window as it appears by default.](media/POage024.jpg)
 
 2.  Select a default order method for automatically generated purchase orders.
 


### PR DESCRIPTION
Fixed: 

- image-alt-text-duplicated errors (duplicate alt text descriptions within an article)
- duplicate-descriptions errors (description is duplicated in another article/other articles)

This PR fixes 38 issues across 8 files and is part of ongoing Validation cleanup efforts. No other content has been edited or added.