### PR TITLE
Validation: Fixed image-alt-text-duplicated issues

### DIFF
--- a/dynamics-gp/financials/receivables-management-part2-transaction-entry.md
+++ b/dynamics-gp/financials/receivables-management-part2-transaction-entry.md
@@ -1,6 +1,6 @@
 ---
 title: "Receivables Management Part 2: Transaction entry"
-description: "Managing receivables in Dynamics GP."
+description: Learn about creating batches and entering various types of transactions, distributions, commissions, and cash receipts.
 keywords: "receivables"
 author: theley502
 ms.prod: dynamics-gp

--- a/dynamics-gp/financials/receivables-management-part3-transaction-activity.md
+++ b/dynamics-gp/financials/receivables-management-part3-transaction-activity.md
@@ -460,7 +460,7 @@ Use the Customer/Vendor Relationships window to link a customer to a vendor or a
 
 1. Open the Customer/Vendor Relationships window. (Sales \>\> Cards \>\> Customer/Vendor)
 
-   ![1e7d912d783aeb7fb89d71205efe68a4.jpg](media/1e7d912d783aeb7fb89d71205efe68a4.jpg)
+   ![Screenshot of Customer/Vender relationships window, before information has been input.](media/1e7d912d783aeb7fb89d71205efe68a4.jpg)
 
 2. Enter or select a vendor and a customer. You can create more than one customer/vendor relationship at a time in this window by entering multiple customers and vendors.
 
@@ -496,7 +496,7 @@ Use the Customer/Vendor Consolidations window to create consolidation documents 
 
 1. Open the Customer/Vendor Consolidations window. (Sales \>\> Transactions \>\> Customer/Vendor Trx.)
 
-    ![91622f2488ad897b2334f1007d0d7e36.jpg](media/91622f2488ad897b2334f1007d0d7e36.jpg)
+    ![Screenshot of Customer/Vendor Consolidations window, showing default entries and empty input boxes.](media/91622f2488ad897b2334f1007d0d7e36.jpg)
 
 2. Mark Customer to display the customer ID first or Vendor to display the vendor ID first.
 
@@ -576,7 +576,7 @@ Use the Refund Checks Setup window to specify your preferences and default entri
 
 1. Open the Refund Checks Setup window. (Sales \>\> Setup \>\> Refund Checks)
 
-   ![efca27cbe1af7aef5c52b7ee89424bfb.jpg](media/efca27cbe1af7aef5c52b7ee89424bfb.jpg)
+   ![Screenshot of Paid Sales Transaction Removal window, showing default entries and empty input boxes.](media/efca27cbe1af7aef5c52b7ee89424bfb.jpg)
 
 2. Enter or select a default suspense account number, which is an offset account for your Accounts Receivable and Accounts Payable amounts. The account you enter or select must be a posting account, and must be set up to use all the currencies in which you're writing checks.
 
@@ -825,7 +825,7 @@ If you void a multicurrency document, any realized gains or losses that original
 
 4. Choose NSF to open the Auto Post NSF Debit Charge window.
 
-    ![586b43b1da4b84e6722d4f6151174a13.jpg](media/586b43b1da4b84e6722d4f6151174a13.jpg)
+    ![Screenshot of window, showing entries for an example NSF charge of fifteen dollars.](media/586b43b1da4b84e6722d4f6151174a13.jpg)
 
     The payment is unapplied and distributions are reversed. Using the NSF Debit Charge window, you can change the default charge for the NSF check, and view the document number assigned to the debit memo that's created.
 
@@ -942,7 +942,7 @@ Use the Edit Receivables Transaction window to change the discount date, due dat
 
 1. Open the Edit Receivables Transaction window. (Sales \>\> Transactions \>\> Edit Transaction Information)
 
-   ![da196509e1d0f1b7d4121cacec00db80.jpg](media/da196509e1d0f1b7d4121cacec00db80.jpg)
+   ![Screenshot of Edit Receivables Transaction window, showing default entries and empty input boxes.](media/da196509e1d0f1b7d4121cacec00db80.jpg)
 
 2. Enter or select a customer ID.
 
@@ -1034,7 +1034,7 @@ Use the Write Off Documents window to write off outstanding document credit or d
 
 1. Open the Write Off Documents window. (Sales \>\> Routines \>\> Write Off Documents)
 
-    ![7e6639d4c44c587c8c3e7a51f73aeb6d.jpg](media/7e6639d4c44c587c8c3e7a51f73aeb6d.jpg)
+    ![Screenshot of window, showing example entries for an eighty dollar writeoff limit.](media/7e6639d4c44c587c8c3e7a51f73aeb6d.jpg)
 
 2. In the Writeoff Type field, select Overpayments to write off customer document credit balances, or select Underpayments to write off customer document debit balances.
 

--- a/dynamics-gp/financials/receivables-management-part3-transaction-activity.md
+++ b/dynamics-gp/financials/receivables-management-part3-transaction-activity.md
@@ -460,7 +460,7 @@ Use the Customer/Vendor Relationships window to link a customer to a vendor or a
 
 1. Open the Customer/Vendor Relationships window. (Sales \>\> Cards \>\> Customer/Vendor)
 
-   ![Screenshot of Customer/Vender relationships window, before information has been input.](media/1e7d912d783aeb7fb89d71205efe68a4.jpg)
+   ![Screenshot of the Customer/Vender relationships window, before information is input.](media/1e7d912d783aeb7fb89d71205efe68a4.jpg)
 
 2. Enter or select a vendor and a customer. You can create more than one customer/vendor relationship at a time in this window by entering multiple customers and vendors.
 
@@ -496,7 +496,7 @@ Use the Customer/Vendor Consolidations window to create consolidation documents 
 
 1. Open the Customer/Vendor Consolidations window. (Sales \>\> Transactions \>\> Customer/Vendor Trx.)
 
-    ![Screenshot of Customer/Vendor Consolidations window, showing default entries and empty input boxes.](media/91622f2488ad897b2334f1007d0d7e36.jpg)
+    ![Screenshot of the Customer/Vendor Consolidations window, showing default entries and empty input boxes.](media/91622f2488ad897b2334f1007d0d7e36.jpg)
 
 2. Mark Customer to display the customer ID first or Vendor to display the vendor ID first.
 
@@ -576,7 +576,7 @@ Use the Refund Checks Setup window to specify your preferences and default entri
 
 1. Open the Refund Checks Setup window. (Sales \>\> Setup \>\> Refund Checks)
 
-   ![Screenshot of Paid Sales Transaction Removal window, showing default entries and empty input boxes.](media/efca27cbe1af7aef5c52b7ee89424bfb.jpg)
+   ![Screenshot of the Paid Sales Transaction Removal window, showing default entries and empty input boxes.](media/efca27cbe1af7aef5c52b7ee89424bfb.jpg)
 
 2. Enter or select a default suspense account number, which is an offset account for your Accounts Receivable and Accounts Payable amounts. The account you enter or select must be a posting account, and must be set up to use all the currencies in which you're writing checks.
 
@@ -825,7 +825,7 @@ If you void a multicurrency document, any realized gains or losses that original
 
 4. Choose NSF to open the Auto Post NSF Debit Charge window.
 
-    ![Screenshot of window, showing entries for an example NSF charge of fifteen dollars.](media/586b43b1da4b84e6722d4f6151174a13.jpg)
+    ![Screenshot of the window, showing entries for an example NSF charge of fifteen dollars.](media/586b43b1da4b84e6722d4f6151174a13.jpg)
 
     The payment is unapplied and distributions are reversed. Using the NSF Debit Charge window, you can change the default charge for the NSF check, and view the document number assigned to the debit memo that's created.
 
@@ -942,7 +942,7 @@ Use the Edit Receivables Transaction window to change the discount date, due dat
 
 1. Open the Edit Receivables Transaction window. (Sales \>\> Transactions \>\> Edit Transaction Information)
 
-   ![Screenshot of Edit Receivables Transaction window, showing default entries and empty input boxes.](media/da196509e1d0f1b7d4121cacec00db80.jpg)
+   ![Screenshot of the Edit Receivables Transaction window, showing default entries and empty input boxes.](media/da196509e1d0f1b7d4121cacec00db80.jpg)
 
 2. Enter or select a customer ID.
 
@@ -1034,7 +1034,7 @@ Use the Write Off Documents window to write off outstanding document credit or d
 
 1. Open the Write Off Documents window. (Sales \>\> Routines \>\> Write Off Documents)
 
-    ![Screenshot of window, showing example entries for an eighty dollar writeoff limit.](media/7e6639d4c44c587c8c3e7a51f73aeb6d.jpg)
+    ![Screenshot of the window, showing example entries for an eighty dollar writeoff limit.](media/7e6639d4c44c587c8c3e7a51f73aeb6d.jpg)
 
 2. In the Writeoff Type field, select Overpayments to write off customer document credit balances, or select Underpayments to write off customer document debit balances.
 

--- a/dynamics-gp/financials/receivables-management-part4-inquiries-reports.md
+++ b/dynamics-gp/financials/receivables-management-part4-inquiries-reports.md
@@ -1,6 +1,6 @@
 ---
 title: "Receivables Management Part 4: Inquiries and reports"
-description: "Managing receivables in Dynamics GP."
+description: Learn how to analyze information entered into the system, customer activity and transaction information, and display the information on a screen or a report.
 keywords: "receivables"
 author: theley502
 ms.prod: dynamics-gp

--- a/dynamics-gp/financials/receivables-management-part5-utilities-routines.md
+++ b/dynamics-gp/financials/receivables-management-part5-utilities-routines.md
@@ -249,7 +249,7 @@ Use the Reconcile Receivables Amounts window to compare the aging period amounts
 1. Open the Reconcile Receivables Amounts window. 
 (Sales \>\> Utilities \>\> Reconcile)
 
-![A screenshot of a cell phone Description automatically generated](media/ce91a731d7706f5ec07a80e585ffce6a.jpg)
+![Screenshot of Reconcile Receivables Amounts window, showing default entries and empty input boxes.](media/ce91a731d7706f5ec07a80e585ffce6a.jpg)
 
 2. Mark which information to reconcile. See *Types of information you can reconcile* for more information.
 
@@ -335,7 +335,7 @@ Use the Remove Receivables Transaction History window to remove transaction hist
 2. Open the Remove Receivables Transaction History window. 
 (Sales \>\> Utilities \>\> Remove Transaction History)
 
-    ![A screenshot of a cell phone Description automatically generated](media/44dff2a477eb56b6647eea009ec07665.jpg)
+    ![Screenshot of Remove Receivables Transaction History window, showing default entries and empty input boxes.](media/44dff2a477eb56b6647eea009ec07665.jpg)
 
 3. To limit the historical records to be removed, select a type of range and enter a range restriction.
 
@@ -570,7 +570,7 @@ Unapplied Credit Amounts in the Receivables Management Setup window.
 
 1. Open the Receivables Aging Process window. (Sales \>\> Routines \>\> Aging)
 
-    ![A screenshot of a cell phone Description automatically generated](media/3a9ea125e5a594587a96f67780448078.jpg)
+    ![Screenshot of Receivables Aging Process window, showing default entries and empty input boxes.](media/3a9ea125e5a594587a96f67780448078.jpg)
 
 1. Enter the date to be used for determining the age of a document. This date
     is compared to either the due date or document date, depending on the
@@ -727,7 +727,7 @@ page 82 for more information on individual finance charges.
 1. Open the Assess Finance Charges window. (Sales \>\> Routines \>\> Finance
     Charge)
 
-    ![A screenshot of a cell phone Description automatically generated](media/3b30a34e701e5595e62802b20f6a3f22.jpg)
+    ![Screenshot of Assess Finance Charges window, showing default entries and empty input boxes.](media/3b30a34e701e5595e62802b20f6a3f22.jpg)
 
 1. Select a range of customer cards to assess finance charges for.
 
@@ -876,7 +876,7 @@ statement ID, change the dates if necessary, and begin printing.
 1. Open the Print Receivables Statements window. (Sales \>\> Routines \>\>
     Statements)
 
-    ![A screenshot of a cell phone Description automatically generated](media/a067d13d4cbdffd28515a179b7544686.jpg)
+    ![Screenshot of Print Receivables Statements window, showing default entries and empty input boxes.](media/a067d13d4cbdffd28515a179b7544686.jpg)
 
 1. Enter or select a statement ID and enter a description. For example, if you
     want to print statements for your open item customers, you can enter Open
@@ -931,7 +931,7 @@ also can include individual child statements.
 2. To create a message, choose Messages to open the Sales Statement Message
     Entry window.
 
-    ![A screenshot of a social media post Description automatically generated](media/a549a0d9e2e4a8b1d28d7ecd46ca4cde.jpg)
+    ![Screenshot of window, showing example descriptions, including Finance Charges, NSF Check Charge, and Current. There is one example message that states, finance charges for 1%.](media/a549a0d9e2e4a8b1d28d7ecd46ca4cde.jpg)
 
 Using this window, you can enter your own message. Each of the situations in
 the description column can have its own message and is printed on any
@@ -1131,7 +1131,7 @@ Statements)
 2. Choose E-mail Options to open the E-mail Statements Options or E-mail
     Reprint Statements Options window.
 
-    ![A screenshot of a cell phone Description automatically generated](media/e755fb09b00080dfe7eadc23c24d9075.jpg)
+    ![Screenshot of window, showing selections of send email customer statements and long form.  Statement is entered in the E mail subject line.](media/e755fb09b00080dfe7eadc23c24d9075.jpg)
 
 1. Mark one of the following options:
 
@@ -1252,7 +1252,7 @@ You can save VAT report IDs and reprint reports at a later time.
 1. Open the VAT Return window. (Administration \>\> Routines \>\> Company \>\>
     VAT Return)
 
-    ![A screenshot of a social media post Description automatically generated](media/a3eca87112499476983c71cd6f53a317.jpg)
+    ![Screenshot of VAT Return window, showing default entries and empty input boxes.](media/a3eca87112499476983c71cd6f53a317.jpg)
 
 1. Enter or select a report ID.
 
@@ -1410,7 +1410,7 @@ have a current backup, you can restore information, if necessary.
 1. Open the Receivables Year-End Closing window. (Sales \>\> Routines \>\>
     Year-End Close)
 
-    ![A screenshot of a cell phone Description automatically generated](media/575bde0d83376ccf27fee01112f9e355.jpg)
+    ![Screenshot of window, showing the selection all for Year to close. The Print Report box is checked.](media/575bde0d83376ccf27fee01112f9e355.jpg)
 
 1. Mark Calendar or, if the calendar year coincides with your fiscal year, mark
     All. If they don't coincide, close the fiscal year separately. See *Closing

--- a/dynamics-gp/financials/receivables-management-part5-utilities-routines.md
+++ b/dynamics-gp/financials/receivables-management-part5-utilities-routines.md
@@ -249,7 +249,7 @@ Use the Reconcile Receivables Amounts window to compare the aging period amounts
 1. Open the Reconcile Receivables Amounts window. 
 (Sales \>\> Utilities \>\> Reconcile)
 
-![Screenshot of Reconcile Receivables Amounts window, showing default entries and empty input boxes.](media/ce91a731d7706f5ec07a80e585ffce6a.jpg)
+![Screenshot of the Reconcile Receivables Amounts window, showing default entries and empty input boxes.](media/ce91a731d7706f5ec07a80e585ffce6a.jpg)
 
 2. Mark which information to reconcile. See *Types of information you can reconcile* for more information.
 
@@ -335,7 +335,7 @@ Use the Remove Receivables Transaction History window to remove transaction hist
 2. Open the Remove Receivables Transaction History window. 
 (Sales \>\> Utilities \>\> Remove Transaction History)
 
-    ![Screenshot of Remove Receivables Transaction History window, showing default entries and empty input boxes.](media/44dff2a477eb56b6647eea009ec07665.jpg)
+    ![Screenshot of the Remove Receivables Transaction History window, showing default entries and empty input boxes.](media/44dff2a477eb56b6647eea009ec07665.jpg)
 
 3. To limit the historical records to be removed, select a type of range and enter a range restriction.
 
@@ -570,7 +570,7 @@ Unapplied Credit Amounts in the Receivables Management Setup window.
 
 1. Open the Receivables Aging Process window. (Sales \>\> Routines \>\> Aging)
 
-    ![Screenshot of Receivables Aging Process window, showing default entries and empty input boxes.](media/3a9ea125e5a594587a96f67780448078.jpg)
+    ![Screenshot of the Receivables Aging Process window, showing default entries and empty input boxes.](media/3a9ea125e5a594587a96f67780448078.jpg)
 
 1. Enter the date to be used for determining the age of a document. This date
     is compared to either the due date or document date, depending on the
@@ -727,7 +727,7 @@ page 82 for more information on individual finance charges.
 1. Open the Assess Finance Charges window. (Sales \>\> Routines \>\> Finance
     Charge)
 
-    ![Screenshot of Assess Finance Charges window, showing default entries and empty input boxes.](media/3b30a34e701e5595e62802b20f6a3f22.jpg)
+    ![Screenshot of the Assess Finance Charges window, showing default entries and empty input boxes.](media/3b30a34e701e5595e62802b20f6a3f22.jpg)
 
 1. Select a range of customer cards to assess finance charges for.
 
@@ -876,7 +876,7 @@ statement ID, change the dates if necessary, and begin printing.
 1. Open the Print Receivables Statements window. (Sales \>\> Routines \>\>
     Statements)
 
-    ![Screenshot of Print Receivables Statements window, showing default entries and empty input boxes.](media/a067d13d4cbdffd28515a179b7544686.jpg)
+    ![Screenshot of the Print Receivables Statements window, showing default entries and empty input boxes.](media/a067d13d4cbdffd28515a179b7544686.jpg)
 
 1. Enter or select a statement ID and enter a description. For example, if you
     want to print statements for your open item customers, you can enter Open
@@ -931,7 +931,7 @@ also can include individual child statements.
 2. To create a message, choose Messages to open the Sales Statement Message
     Entry window.
 
-    ![Screenshot of window, showing example descriptions, including Finance Charges, NSF Check Charge, and Current. There is one example message that states, finance charges for 1%.](media/a549a0d9e2e4a8b1d28d7ecd46ca4cde.jpg)
+    ![Screenshot of the window, showing example descriptions, including Finance Charges, NSF Check Charge, and Current. There is one example message that states, finance charges for 1%.](media/a549a0d9e2e4a8b1d28d7ecd46ca4cde.jpg)
 
 Using this window, you can enter your own message. Each of the situations in
 the description column can have its own message and is printed on any
@@ -1131,7 +1131,7 @@ Statements)
 2. Choose E-mail Options to open the E-mail Statements Options or E-mail
     Reprint Statements Options window.
 
-    ![Screenshot of window, showing selections of send email customer statements and long form.  Statement is entered in the E mail subject line.](media/e755fb09b00080dfe7eadc23c24d9075.jpg)
+    ![Screenshot of the window, showing selections of send email customer statements and long form.  Statement is entered in the email subject line.](media/e755fb09b00080dfe7eadc23c24d9075.jpg)
 
 1. Mark one of the following options:
 
@@ -1252,7 +1252,7 @@ You can save VAT report IDs and reprint reports at a later time.
 1. Open the VAT Return window. (Administration \>\> Routines \>\> Company \>\>
     VAT Return)
 
-    ![Screenshot of VAT Return window, showing default entries and empty input boxes.](media/a3eca87112499476983c71cd6f53a317.jpg)
+    ![Screenshot of the VAT Return window, showing default entries and empty input boxes.](media/a3eca87112499476983c71cd6f53a317.jpg)
 
 1. Enter or select a report ID.
 
@@ -1410,7 +1410,7 @@ have a current backup, you can restore information, if necessary.
 1. Open the Receivables Year-End Closing window. (Sales \>\> Routines \>\>
     Year-End Close)
 
-    ![Screenshot of window, showing the selection All for Year to Close. The Print Report box is checked.](media/575bde0d83376ccf27fee01112f9e355.jpg)
+    ![Screenshot of the window, showing the selection All for Year to Close. The Print Report box is checked.](media/575bde0d83376ccf27fee01112f9e355.jpg)
 
 1. Mark Calendar or, if the calendar year coincides with your fiscal year, mark
     All. If they don't coincide, close the fiscal year separately. See *Closing

--- a/dynamics-gp/financials/receivables-management-part5-utilities-routines.md
+++ b/dynamics-gp/financials/receivables-management-part5-utilities-routines.md
@@ -1410,7 +1410,7 @@ have a current backup, you can restore information, if necessary.
 1. Open the Receivables Year-End Closing window. (Sales \>\> Routines \>\>
     Year-End Close)
 
-    ![Screenshot of window, showing the selection all for Year to close. The Print Report box is checked.](media/575bde0d83376ccf27fee01112f9e355.jpg)
+    ![Screenshot of window, showing the selection All for Year to Close. The Print Report box is checked.](media/575bde0d83376ccf27fee01112f9e355.jpg)
 
 1. Mark Calendar or, if the calendar year coincides with your fiscal year, mark
     All. If they don't coincide, close the fiscal year separately. See *Closing

--- a/dynamics-gp/financials/receivables-management.md
+++ b/dynamics-gp/financials/receivables-management.md
@@ -1,6 +1,6 @@
 ---
 title: "Receivables Management in Dynamics GP"
-description: "Managing receivables in Dynamics GP."
+description: Learn how to use Receivables Management to set up, enter, and maintain records, salesperson and sales territory information, accounts, and transactions.
 keywords: "receivables"
 author: theley502
 ms.prod: dynamics-gp
@@ -318,7 +318,7 @@ Use the Receivables Management Setup window to set up the aging periods to use, 
 1. Open the Receivables Management Setup window.
     (Sales \>\> Setup \>\> Receivables)
 
-    ![A screenshot of a cell phone Description automatically generated](media/7a5ea1dd33f3297cf5418e678934dfa2.jpg)
+    ![Screenshot of window, showing aging periods, passwords, options selected, and default pricing information.](media/7a5ea1dd33f3297cf5418e678934dfa2.jpg)
 
 2. Specify the aging periods to use and how to age documents. See *Aging periods* for more information.
 
@@ -380,7 +380,7 @@ Use the Receivables Setup Options window to set up options to appear throughout 
 1. Open the Receivables Setup Options window.
 (Sales \>\> Setup \>\> Receivables \>\> Options button)
 
-    ![A screenshot of a cell phone Description automatically generated](media/ae7cb7069d72add6f2e37c7f940a6c5e.jpg)
+    ![Screenshot of window, showing input boxes for description, code, date of last, and default tax schedule IDs.](media/ae7cb7069d72add6f2e37c7f940a6c5e.jpg)
 
 2. Specify default transaction descriptions, codes, and next numbers.
 
@@ -426,7 +426,7 @@ You also can enter beginning territory sales amounts. These amounts are updated 
 
 2. In the New group, choose Sales Territory to open the Sales Territory Maintenance window.
 
-    ![A screenshot of a cell phone Description automatically generated](media/eb594930a3c07eb33434f954ad58f1a4.jpg)
+    ![Screenshot of Sales Territory Maintenance window, showing default and empty input boxes.](media/eb594930a3c07eb33434f954ad58f1a4.jpg)
 
 3. Enter an ID and a description for the territory.
 
@@ -485,7 +485,7 @@ You can assign a salesperson to each customer card. Transactions for the custome
 
 2. In the New group, choose Salesperson to open the Salesperson Maintenance window.
 
-    ![A screenshot of a cell phone Description automatically generated](media/23348071978419672f7680e58b608502.jpg)
+    ![Screenshot of Salesperson Maintenance window, showing default and empty input boxes.](media/23348071978419672f7680e58b608502.jpg)
 
 3. Enter a salesperson ID and name. If this salesperson is an employee, enter the employee ID; the employee record information appears. The salesperson ID doesn’t have to be the same as the employee ID.
 
@@ -613,7 +613,7 @@ Use the Customer Class Setup window to enter new customer classes. In addition, 
 1. Open the Customer Class Setup window.
 (Sales \>\> Setup \>\> Customer Class)
 
-    ![A screenshot of a cell phone Description automatically generated](media/f8b925deef3e2f31d68ec071be97a4ef.jpg)
+    ![Screenshot of Customer Class Setup window, showing default selections and empty input boxes.](media/f8b925deef3e2f31d68ec071be97a4ef.jpg)
 
 2. Enter an ID and description for the class.
 
@@ -672,7 +672,7 @@ See the System Setup documentation for information about setting up Intrastat co
 1. Open the Customer Class Intrastat Setup window.
 (Sales \>\> Setup \>\> Customer Class \>\> Select a customer class \>\>Intrastat button)
 
-    ![A screenshot of a cell phone Description automatically generated](media/0a29d884a9262fcdd7051a9d07feb026.jpg)
+    ![Screenshot of Customer Class Intrastat Setup window, showing default and empty input boxes.](media/0a29d884a9262fcdd7051a9d07feb026.jpg)
 
 2. Enter or select country, transport mode, transaction nature, incoterms, procedure/regime, port, region, and tax commodity codes for the customer class.
 
@@ -696,7 +696,7 @@ You can post other types of distributions either to Inventory or Receivables Man
 1. Open the Customer Class Accounts Setup window.
 (Sales \>\> Setup \>\> Customer Class \>\> Accounts button)
 
-    ![A screenshot of a cell phone Description automatically generated](media/3cd7047b7669f415246f6616cfd69d8a.jpg)
+    ![Screenshot of window, showing example checkbook account numbers and descriptions.](media/3cd7047b7669f415246f6616cfd69d8a.jpg)
 
 2. If you didn’t specify a class ID using the previous window, enter or select a class ID and enter a description.
 
@@ -754,7 +754,7 @@ Use the Customer Maintenance window to add customer cards to your Receivables Ma
 
 2. In the New group, choose Customer to open the Customer Maintenance window.
 
-    ![A screenshot of a cell phone Description automatically generated](media/b2c1c15b1b4e180e1f911a4f57d5836f.jpg)
+    ![Screenshot of window, showing example customer ID, Address, phone, and shipping information.](media/b2c1c15b1b4e180e1f911a4f57d5836f.jpg)
 
 3. Enter a customer ID and name information. The short name, such as the company’s initials, can be used in circumstances when the customer name is too long. Short names may appear on reports and can be used as a sorting option for reports. The statement name is the name that is printed on statements.
 
@@ -813,7 +813,7 @@ You can post other types of distributions either to Inventory or Receivables Man
 1. Open the Customer Account Maintenance window.
 (Sales \>\> Cards \>\> Customer \>\> Select a customer ID \>\> Accounts)
 
-    ![A screenshot of a cell phone Description automatically generated](media/e8a98ea488c3534fd46e195c024e30e9.jpg)
+    ![Screenshot of window, showing example customer account numbers and descriptions.](media/e8a98ea488c3534fd46e195c024e30e9.jpg)
 
 2. Mark whether to use the Cash account from the checkbook you selected using the Receivables Management Setup window, or from the customer card.
 
@@ -907,7 +907,7 @@ If you entered a class ID for this customer, the options you entered using the C
 1. Open the Customer Maintenance Options window.
     (Sales \>\> Cards \>\> Customer \>\> Select a customer ID \>\> Options)
 
-    ![A screenshot of a cell phone Description automatically generated](media/7284ab89ed33f1e7b54bbdeedd175148.jpg)
+    ![Screenshot of window, showing customer payment and payment type information, with options to send E mail statements at the bottom.](media/7284ab89ed33f1e7b54bbdeedd175148.jpg)
 
 2. Set up the credit options to apply to the customer, such as balance type, finance charge, minimum payment, credit limit, and writeoff.
 
@@ -955,7 +955,7 @@ The options available in this window depend on the selections you made in the Co
 1. Open the Customer E-mail Options window.
     (Sales \>\> Cards \>\> Customer \>\> Select a customer ID \>\> E-mail)
 
-    ![A screenshot of a cell phone Description automatically generated](media/e37074ea483afcfb34c563ed5c450815.jpg)
+    ![Screenshot of window, showing options for which forms can be sent as E mails and which formats those forms may have.](media/e37074ea483afcfb34c563ed5c450815.jpg)
 
 2. Select to send documents as attachments or embed documents in the message body. The options available depend on the selections in the Company E-mail Setup window.
 
@@ -991,7 +991,7 @@ The options available in this window depend on the selections you made in the Co
 
 3. In the Modify group, click the overflow menu and then select E-mail Settings to open the Mass Customer E-mail Settings window.
 
-    ![A screenshot of a cell phone Description automatically generated](media/8b43d633881e5e9fbfa80346d5a01a9d.jpg)
+    ![Screenshot of window, showing the option to send documents as attachments is selected.](media/8b43d633881e5e9fbfa80346d5a01a9d.jpg)
 
 4. Select to send documents as attachments or embed documents in the body of email messages.
 
@@ -1168,7 +1168,7 @@ Use the Customer Mass Delete window to delete a range of customer cards.
 1. Open the Customer Mass Delete window. 
 (Sales \>\> Utilities \>\> Mass Delete)
 
-    ![A screenshot of a cell phone Description automatically generated](media/32a89d099e0cb3d12963f05b6f10c8ab.jpg)
+    ![Screenshot of window, showing the range to be by customer ID and that only inactive customers are to be selected.](media/32a89d099e0cb3d12963f05b6f10c8ab.jpg)
 
 2. Enter or select a range of customer cards to delete.
 
@@ -1226,7 +1226,7 @@ Use the Posting Setup window to change your posting settings so your transaction
 
 1. Open the Posting Setup window. (Administration \>\> Setup \>\> Posting \>\> Posting)
 
-    ![A screenshot of a cell phone Description automatically generated](media/d1514b8a8089495db7193701a1523ab0.jpg)
+    ![Screenshot of window, showing default selections and example report entries.](media/d1514b8a8089495db7193701a1523ab0.jpg)
 
 2. Select Sales as the series and Receivables Sales Entry as the origin.
 
@@ -1246,7 +1246,7 @@ You can enter transactions in detail or summary form, depending on your company�
 1. Open the Receivables Batch Entry window. 
 (Sales \>\> Transactions \>\> Receivables Batches)
 
-    ![A screenshot of a cell phone Description automatically generated](media/eb6b83b543a3050e727b2eadf496eaba.jpg)
+    ![Screenshot of Receivables Batch Entry window, showing default entries and empty input boxes.](media/eb6b83b543a3050e727b2eadf496eaba.jpg)
 
 2. Enter a batch ID, such as BBAL, and select Transaction Entry as the batch origin for transactions. See *Chapter 11, “Batches,”* for more information about batches.
 
@@ -1398,7 +1398,7 @@ Use the Paid Sales Transaction Removal window to consolidate period balances and
 1. Open the Paid Sales Transaction Removal window. 
     (Sales \>\> Routines \>\> Paid Transaction Removal)
 
-    ![A screenshot of a cell phone Description automatically generated](media/98eb8bf73693f25fbc44f7d637cc44fc.jpg)
+    ![Screenshot of Paid Sales Transaction Removal window, showing default entries and empty input boxes.](media/98eb8bf73693f25fbc44f7d637cc44fc.jpg)
 
 2. Mark All for the range of customers or classes.
 
@@ -1487,7 +1487,7 @@ Closing the fiscal year will not affect the information that is displayed in the
 1. Open the Customer Summary window. 
 (Sales \>\> Cards \>\> Summary)
 
-    ![A screenshot of a cell phone Description automatically generated](media/7931fc6c5e37ffead12c50d18e7a08dd.jpg)
+    ![Screenshot of window, showing an example payment history for sample customer number 1 who has paid one thousand, one hundred and seventy seven dollars.](media/7931fc6c5e37ffead12c50d18e7a08dd.jpg)
 
 2. Enter or select a customer ID.
 
@@ -1516,7 +1516,7 @@ Use the Customer Period Summary window to enter historical amounts per period—
 1. Open the Customer Period Summary window.
     (Sales \>\> Cards \>\> Summary \>\> Select a customer ID \>\> History button)
 
-    ![A screenshot of a cell phone Description automatically generated](media/f91a7db1fc70dcc4b99a206069e00c54.jpg)
+    ![Screenshot of Customer Period Summary window, showing default and empty input boxes.](media/f91a7db1fc70dcc4b99a206069e00c54.jpg)
 
 2. Mark Calendar or Fiscal, depending on the type of history you’re entering.
 
@@ -1539,7 +1539,7 @@ Use the Customer Finance Charge Summary window to track current and previous fin
 1. Open the Customer Finance Charge Summary window.
     (Sales \>\> Cards \>\> Summary \>\> Select a customer ID \>\> Finance Charges button)
 
-    ![A screenshot of a cell phone Description automatically generated](media/2f644e610b86d6798f47aa6d82684720.jpg)
+    ![Screenshot of Customer Finance Charge Summary window for customer number one, showing default and empty input boxes.](media/2f644e610b86d6798f47aa6d82684720.jpg)
 
 2. Enter the Last Charge Amount.
 
@@ -1560,7 +1560,7 @@ Use the Customer Credit Summary window to enter information about the average nu
 1. Open the Customer Credit Summary window.
     (Sales \>\> Cards \>\> Summary \>\> Select a customer ID \>\> Credit Summary button)
 
-    ![A screenshot of a cell phone Description automatically generated](media/6c90941fface7a62bbfb379027ad66b7.jpg)
+    ![Screenshot of window, showing example inputs for customer number one after a one hundred dollar payment on a one thousand and seventy dollar invoice.](media/6c90941fface7a62bbfb379027ad66b7.jpg)
 
 2. Enter the Average Days to Pay for the current year to date and life to date.
 
@@ -1633,7 +1633,7 @@ Use the National Accounts Maintenance window to add new national accounts to you
 1. Open the National Accounts Maintenance window.
     (Sales \>\> Cards \>\> National Accounts)
 
-    ![A screenshot of a cell phone Description automatically generated](media/a3b774fc7e6430ed6c401b679a5fbc51.jpg)
+    ![Screenshot of National Accounts Maintenance window, showing default and empty input boxes.](media/a3b774fc7e6430ed6c401b679a5fbc51.jpg)
 
 2. Enter or select a parent customer ID.
 

--- a/dynamics-gp/financials/receivables-management.md
+++ b/dynamics-gp/financials/receivables-management.md
@@ -318,7 +318,7 @@ Use the Receivables Management Setup window to set up the aging periods to use, 
 1. Open the Receivables Management Setup window.
     (Sales \>\> Setup \>\> Receivables)
 
-    ![Screenshot of window, showing aging periods, passwords, options selected, and default pricing information.](media/7a5ea1dd33f3297cf5418e678934dfa2.jpg)
+    ![Screenshot of the window, showing aging periods, passwords, options selected, and default pricing information.](media/7a5ea1dd33f3297cf5418e678934dfa2.jpg)
 
 2. Specify the aging periods to use and how to age documents. See *Aging periods* for more information.
 
@@ -380,7 +380,7 @@ Use the Receivables Setup Options window to set up options to appear throughout 
 1. Open the Receivables Setup Options window.
 (Sales \>\> Setup \>\> Receivables \>\> Options button)
 
-    ![Screenshot of window, showing input boxes for description, code, date of last, and default tax schedule IDs.](media/ae7cb7069d72add6f2e37c7f940a6c5e.jpg)
+    ![Screenshot of the window, showing input boxes for description, code, date of last, and default tax schedule IDs.](media/ae7cb7069d72add6f2e37c7f940a6c5e.jpg)
 
 2. Specify default transaction descriptions, codes, and next numbers.
 
@@ -426,7 +426,7 @@ You also can enter beginning territory sales amounts. These amounts are updated 
 
 2. In the New group, choose Sales Territory to open the Sales Territory Maintenance window.
 
-    ![Screenshot of Sales Territory Maintenance window, showing default and empty input boxes.](media/eb594930a3c07eb33434f954ad58f1a4.jpg)
+    ![Screenshot of the Sales Territory Maintenance window, showing default and empty input boxes.](media/eb594930a3c07eb33434f954ad58f1a4.jpg)
 
 3. Enter an ID and a description for the territory.
 
@@ -485,7 +485,7 @@ You can assign a salesperson to each customer card. Transactions for the custome
 
 2. In the New group, choose Salesperson to open the Salesperson Maintenance window.
 
-    ![Screenshot of Salesperson Maintenance window, showing default and empty input boxes.](media/23348071978419672f7680e58b608502.jpg)
+    ![Screenshot of the Salesperson Maintenance window, showing default and empty input boxes.](media/23348071978419672f7680e58b608502.jpg)
 
 3. Enter a salesperson ID and name. If this salesperson is an employee, enter the employee ID; the employee record information appears. The salesperson ID doesn’t have to be the same as the employee ID.
 
@@ -613,7 +613,7 @@ Use the Customer Class Setup window to enter new customer classes. In addition, 
 1. Open the Customer Class Setup window.
 (Sales \>\> Setup \>\> Customer Class)
 
-    ![Screenshot of Customer Class Setup window, showing default selections and empty input boxes.](media/f8b925deef3e2f31d68ec071be97a4ef.jpg)
+    ![Screenshot of the Customer Class Setup window, showing default selections and empty input boxes.](media/f8b925deef3e2f31d68ec071be97a4ef.jpg)
 
 2. Enter an ID and description for the class.
 
@@ -672,7 +672,7 @@ See the System Setup documentation for information about setting up Intrastat co
 1. Open the Customer Class Intrastat Setup window.
 (Sales \>\> Setup \>\> Customer Class \>\> Select a customer class \>\>Intrastat button)
 
-    ![Screenshot of Customer Class Intrastat Setup window, showing default and empty input boxes.](media/0a29d884a9262fcdd7051a9d07feb026.jpg)
+    ![Screenshot of the Customer Class Intrastat Setup window, showing default and empty input boxes.](media/0a29d884a9262fcdd7051a9d07feb026.jpg)
 
 2. Enter or select country, transport mode, transaction nature, incoterms, procedure/regime, port, region, and tax commodity codes for the customer class.
 
@@ -696,7 +696,7 @@ You can post other types of distributions either to Inventory or Receivables Man
 1. Open the Customer Class Accounts Setup window.
 (Sales \>\> Setup \>\> Customer Class \>\> Accounts button)
 
-    ![Screenshot of window, showing example checkbook account numbers and descriptions.](media/3cd7047b7669f415246f6616cfd69d8a.jpg)
+    ![Screenshot of the window, showing example checkbook account numbers and descriptions.](media/3cd7047b7669f415246f6616cfd69d8a.jpg)
 
 2. If you didn’t specify a class ID using the previous window, enter or select a class ID and enter a description.
 
@@ -754,7 +754,7 @@ Use the Customer Maintenance window to add customer cards to your Receivables Ma
 
 2. In the New group, choose Customer to open the Customer Maintenance window.
 
-    ![Screenshot of window, showing example customer ID, Address, phone, and shipping information.](media/b2c1c15b1b4e180e1f911a4f57d5836f.jpg)
+    ![Screenshot of the window, showing example customer ID, Address, phone, and shipping information.](media/b2c1c15b1b4e180e1f911a4f57d5836f.jpg)
 
 3. Enter a customer ID and name information. The short name, such as the company’s initials, can be used in circumstances when the customer name is too long. Short names may appear on reports and can be used as a sorting option for reports. The statement name is the name that is printed on statements.
 
@@ -813,7 +813,7 @@ You can post other types of distributions either to Inventory or Receivables Man
 1. Open the Customer Account Maintenance window.
 (Sales \>\> Cards \>\> Customer \>\> Select a customer ID \>\> Accounts)
 
-    ![Screenshot of window, showing example customer account numbers and descriptions.](media/e8a98ea488c3534fd46e195c024e30e9.jpg)
+    ![Screenshot of the window, showing example customer account numbers and descriptions.](media/e8a98ea488c3534fd46e195c024e30e9.jpg)
 
 2. Mark whether to use the Cash account from the checkbook you selected using the Receivables Management Setup window, or from the customer card.
 
@@ -907,7 +907,7 @@ If you entered a class ID for this customer, the options you entered using the C
 1. Open the Customer Maintenance Options window.
     (Sales \>\> Cards \>\> Customer \>\> Select a customer ID \>\> Options)
 
-    ![Screenshot of window, showing customer payment and payment type information, with options to send E mail statements at the bottom.](media/7284ab89ed33f1e7b54bbdeedd175148.jpg)
+    ![Screenshot of the window, showing customer payment and payment type information, with options to send E mail statements at the bottom.](media/7284ab89ed33f1e7b54bbdeedd175148.jpg)
 
 2. Set up the credit options to apply to the customer, such as balance type, finance charge, minimum payment, credit limit, and writeoff.
 
@@ -955,7 +955,7 @@ The options available in this window depend on the selections you made in the Co
 1. Open the Customer E-mail Options window.
     (Sales \>\> Cards \>\> Customer \>\> Select a customer ID \>\> E-mail)
 
-    ![Screenshot of window, showing options for which forms can be sent as E mails and which formats those forms may have.](media/e37074ea483afcfb34c563ed5c450815.jpg)
+    ![Screenshot of the window, showing options for which forms can be sent as E mails and which formats those forms may have.](media/e37074ea483afcfb34c563ed5c450815.jpg)
 
 2. Select to send documents as attachments or embed documents in the message body. The options available depend on the selections in the Company E-mail Setup window.
 
@@ -991,7 +991,7 @@ The options available in this window depend on the selections you made in the Co
 
 3. In the Modify group, click the overflow menu and then select E-mail Settings to open the Mass Customer E-mail Settings window.
 
-    ![Screenshot of window, showing the option to send documents as attachments is selected.](media/8b43d633881e5e9fbfa80346d5a01a9d.jpg)
+    ![Screenshot of the window, showing the option to send documents as attachments is selected.](media/8b43d633881e5e9fbfa80346d5a01a9d.jpg)
 
 4. Select to send documents as attachments or embed documents in the body of email messages.
 
@@ -1168,7 +1168,7 @@ Use the Customer Mass Delete window to delete a range of customer cards.
 1. Open the Customer Mass Delete window. 
 (Sales \>\> Utilities \>\> Mass Delete)
 
-    ![Screenshot of window, showing the range to be by customer ID and that only inactive customers are to be selected.](media/32a89d099e0cb3d12963f05b6f10c8ab.jpg)
+    ![Screenshot of the window, showing the range to be by customer ID and that only inactive customers are to be selected.](media/32a89d099e0cb3d12963f05b6f10c8ab.jpg)
 
 2. Enter or select a range of customer cards to delete.
 
@@ -1226,7 +1226,7 @@ Use the Posting Setup window to change your posting settings so your transaction
 
 1. Open the Posting Setup window. (Administration \>\> Setup \>\> Posting \>\> Posting)
 
-    ![Screenshot of window, showing default selections and example report entries.](media/d1514b8a8089495db7193701a1523ab0.jpg)
+    ![Screenshot of the window, showing default selections and example report entries.](media/d1514b8a8089495db7193701a1523ab0.jpg)
 
 2. Select Sales as the series and Receivables Sales Entry as the origin.
 
@@ -1246,7 +1246,7 @@ You can enter transactions in detail or summary form, depending on your company�
 1. Open the Receivables Batch Entry window. 
 (Sales \>\> Transactions \>\> Receivables Batches)
 
-    ![Screenshot of Receivables Batch Entry window, showing default entries and empty input boxes.](media/eb6b83b543a3050e727b2eadf496eaba.jpg)
+    ![Screenshot of the Receivables Batch Entry window, showing default entries and empty input boxes.](media/eb6b83b543a3050e727b2eadf496eaba.jpg)
 
 2. Enter a batch ID, such as BBAL, and select Transaction Entry as the batch origin for transactions. See *Chapter 11, “Batches,”* for more information about batches.
 
@@ -1398,7 +1398,7 @@ Use the Paid Sales Transaction Removal window to consolidate period balances and
 1. Open the Paid Sales Transaction Removal window. 
     (Sales \>\> Routines \>\> Paid Transaction Removal)
 
-    ![Screenshot of Paid Sales Transaction Removal window, showing default entries and empty input boxes.](media/98eb8bf73693f25fbc44f7d637cc44fc.jpg)
+    ![Screenshot of the Paid Sales Transaction Removal window, showing default entries and empty input boxes.](media/98eb8bf73693f25fbc44f7d637cc44fc.jpg)
 
 2. Mark All for the range of customers or classes.
 
@@ -1487,7 +1487,7 @@ Closing the fiscal year will not affect the information that is displayed in the
 1. Open the Customer Summary window. 
 (Sales \>\> Cards \>\> Summary)
 
-    ![Screenshot of window, showing an example payment history for sample customer number 1 who has paid one thousand, one hundred and seventy seven dollars.](media/7931fc6c5e37ffead12c50d18e7a08dd.jpg)
+    ![Screenshot of the window, showing an example payment history for sample customer number 1 who has paid one thousand, one hundred and seventy seven dollars.](media/7931fc6c5e37ffead12c50d18e7a08dd.jpg)
 
 2. Enter or select a customer ID.
 
@@ -1516,7 +1516,7 @@ Use the Customer Period Summary window to enter historical amounts per period—
 1. Open the Customer Period Summary window.
     (Sales \>\> Cards \>\> Summary \>\> Select a customer ID \>\> History button)
 
-    ![Screenshot of Customer Period Summary window, showing default and empty input boxes.](media/f91a7db1fc70dcc4b99a206069e00c54.jpg)
+    ![Screenshot of the Customer Period Summary window, showing default and empty input boxes.](media/f91a7db1fc70dcc4b99a206069e00c54.jpg)
 
 2. Mark Calendar or Fiscal, depending on the type of history you’re entering.
 
@@ -1539,7 +1539,7 @@ Use the Customer Finance Charge Summary window to track current and previous fin
 1. Open the Customer Finance Charge Summary window.
     (Sales \>\> Cards \>\> Summary \>\> Select a customer ID \>\> Finance Charges button)
 
-    ![Screenshot of Customer Finance Charge Summary window for customer number one, showing default and empty input boxes.](media/2f644e610b86d6798f47aa6d82684720.jpg)
+    ![Screenshot of the Customer Finance Charge Summary window for customer number one, showing default and empty input boxes.](media/2f644e610b86d6798f47aa6d82684720.jpg)
 
 2. Enter the Last Charge Amount.
 
@@ -1560,7 +1560,7 @@ Use the Customer Credit Summary window to enter information about the average nu
 1. Open the Customer Credit Summary window.
     (Sales \>\> Cards \>\> Summary \>\> Select a customer ID \>\> Credit Summary button)
 
-    ![Screenshot of window, showing example inputs for customer number one after a one hundred dollar payment on a one thousand and seventy dollar invoice.](media/6c90941fface7a62bbfb379027ad66b7.jpg)
+    ![Screenshot of the window, showing example inputs for customer number one after a one hundred dollar payment on a one thousand and seventy dollar invoice.](media/6c90941fface7a62bbfb379027ad66b7.jpg)
 
 2. Enter the Average Days to Pay for the current year to date and life to date.
 
@@ -1633,7 +1633,7 @@ Use the National Accounts Maintenance window to add new national accounts to you
 1. Open the National Accounts Maintenance window.
     (Sales \>\> Cards \>\> National Accounts)
 
-    ![Screenshot of National Accounts Maintenance window, showing default and empty input boxes.](media/a3b774fc7e6430ed6c401b679a5fbc51.jpg)
+    ![Screenshot of the National Accounts Maintenance window, showing default and empty input boxes.](media/a3b774fc7e6430ed6c401b679a5fbc51.jpg)
 
 2. Enter or select a parent customer ID.
 


### PR DESCRIPTION
Fixed:

- image-alt-text-duplicated errors (duplicate alt text descriptions within an article)

This PR fixes 39 issues across 5 files and is part of ongoing Validation cleanup efforts. No other content has been edited or added.